### PR TITLE
Add hardware configuration question to 2025 survey

### DIFF
--- a/community/2025/survey.yaml
+++ b/community/2025/survey.yaml
@@ -277,6 +277,14 @@ questions:
       - "23.11 or older"
       - I don't know
       - I don't use NixOS
+  - prompt: How do you configure hardware on NixOS?
+    type: multiple
+    choices:
+      - nixos-generate-config
+      - nixos-hardware repository
+      - nixos-facter
+      - Manual configuration
+      - Other
   - prompt: Which software ecosystems do you use Nix with?
     type: multiple
     choices:


### PR DESCRIPTION
Adds a multiple-choice question asking users how they configure hardware on NixOS, with options including nixos-generate-config, nixos-hardware repository, nixos-facter, manual configuration, and other.