### PR TITLE
Add pipe operators as an option in which experimental features do you use

### DIFF
--- a/community/2025/survey.yaml
+++ b/community/2025/survey.yaml
@@ -340,6 +340,7 @@ questions:
       - "Flakes (`flakes`)"
       - "New `nix` command-line interface (`nix-command`)"
       - "Content-addressed derivations (`ca-derivations`)"
+      - "Pipe Operators `|>` (`pipe-operators`)"
       - "Dynamic derivations (`dynamic-derivations`)"
       - "Git hashing for store objects (`git-hashing`)"
       - "Recursive Nix (`recursive-nix`)"


### PR DESCRIPTION
I use pipe operators in my nix configuration and didn't seem them on this list.

I'm not sure if these experimental features were pre-selected in some way to be ones where you'd like feedback to what to prioritize or anything like that which might mean they were left out on purpose but in case not here is a PR adding them.