### PR TITLE
Add podcast option for how did you first hear about nix

### DIFF
--- a/community/2025/survey.yaml
+++ b/community/2025/survey.yaml
@@ -166,6 +166,7 @@ questions:
       - At school or university
       - From a friend or colleague
       - On a blog or personal website
+      - On a podcast
       - On YouTube
       - On Reddit
       - On Hacker News


### PR DESCRIPTION
I think I originally heard about nix through a podcast - I don't recall exactly but it is discussed enough of various Linux podcast's I'd be unsurprised if a number of community members first encountered it there. 

This could technically fall under 'other' if you don't want to clutter the list but I think it might be enough to warrant it's own option.

I've not checked how common it was as a response in 'other' in previous surveys which might be a good indicator.