### PR TITLE
Split gender identity question in two

### DIFF
--- a/community/2025/survey.yaml
+++ b/community/2025/survey.yaml
@@ -41,12 +41,16 @@ questions:
   - prompt: What is your gender identity?
     type: single
     choices:
-      # https://www.csusm.edu/ipa/surveys/inclusive-language-guidelines.html
       - Man
       - Woman
-      - Transgender
       - Non-binary/non-conforming
       - I identify in another way
+      - Prefer not to say
+  - prompt: Do you identify as transgender?
+    type: single
+    choices:
+      - Yes
+      - No
       - Prefer not to say
   - prompt: How many years of programming experience do you have (including time spent learning or studying)?
     type: single


### PR DESCRIPTION
Fixes #4.

The current phrasing of the question requires transgender people to choose between selecting transgender, and the gender they identify as. This implies that only cisgender women should select "Woman", while binary trans people should "other" themselves. 

This PR changes the question by splitting it in two. Now, a cisgender woman and a transgender woman could both select "Woman" for the gender identity question, and the trans woman can still self-identify as trans if they prefer.