### PR TITLE
fix(site): make survey links base-aware for subpath deploys

### DIFF
--- a/lib/site/src/pages/index.astro
+++ b/lib/site/src/pages/index.astro
@@ -5,6 +5,11 @@ import Layout from '../layouts/Layout.astro';
 const surveys = (await getCollection('results'))
   .filter(r => r.data.year !== 9999)
   .sort((a, b) => b.data.year - a.data.year);
+
+// Base prefix for internal links. import.meta.env.BASE_URL may or may not carry
+// a trailing slash (config `base` adds one; the CLI `--base` flag does not), so
+// normalise to no trailing slash and add exactly one separator below.
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 <Layout title="NixOS Surveys">
   <h1 class="mb-4 text-4xl md:text-5xl font-bold font-heading text-secondary-afghani-blue dark:text-secondary-afghani-blue-75">NixOS Surveys</h1>
@@ -15,7 +20,7 @@ const surveys = (await getCollection('results'))
   <ul class="grid gap-5 list-none p-0 grid-cols-[repeat(auto-fit,minmax(320px,520px))]">
     {surveys.map(s => (
       <li>
-        <a href={`/${s.data.series}/${s.data.year}/`}
+        <a href={`${base}/${s.data.series}/${s.data.year}/`}
            class="block rounded-xl overflow-hidden border-2 border-secondary-afghani-blue dark:border-secondary-afghani-blue-75 bg-primary-white dark:bg-secondary-afghani-blue-15 shadow-sm transition duration-200 p-5 no-underline hover:shadow-md hover:-translate-y-0.5 hover:bg-secondary-afghani-blue-95 dark:hover:bg-secondary-afghani-blue-25">
           <span class="block text-xl font-bold font-heading text-secondary-afghani-blue dark:text-secondary-afghani-blue-75">{s.data.title}</span>
           {s.data.intro_meta && (


### PR DESCRIPTION
## What

The index survey-card link was hard-coded as `/<series>/<year>/`. When the site is built under a base path — e.g. `astro build --base /surveys`, as the `nixos-homepage` flake does to mount this site at `nixos.org/surveys` — that link escapes the base prefix and 404s.

Astro rewrites its *own* asset URLs (and `url()` in imported CSS) for the base, but it does **not** rewrite hand-written `href` strings in `.astro` templates. So we prefix the link with a normalized `import.meta.env.BASE_URL`:

```astro
const base = import.meta.env.BASE_URL.replace(/\/$/, '');
...
<a href={`${base}/${s.data.series}/${s.data.year}/`} …>
```

The `.replace(/\/$/, '')` normalizes the trailing slash, which differs between the config `base` option (has one) and the CLI `--base` flag (does not).

## Verification

Built in both contexts:
- Under `--base /surveys`: link resolves to `/surveys/community/2025/` ✅
- Standalone (base `/`): link resolves to `/community/2025/` (unchanged) ✅

An audit of `lib/site/src` found this was the only hand-written absolute page link; the `#…` heading/ToC anchors are fragments, and the route159 `@font-face` `url()`s are rewritten by Vite for the base automatically.

## Companion change

Mounting at `nixos.org/surveys` also needs the `nixos-homepage` flake to actually stage the survey data during its build (its custom `buildPhase` must `runHook preBuild`) — tracked separately in that repo.